### PR TITLE
Allow to search on all regions or specific regions

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -46,7 +46,8 @@ var regions = new Promise((resolve, reject) => {
 });
 
 Promise
-  .try(() => Promise.all(regions.map((r) => opsWorks(r).describeStacksAsync().get('Stacks'))))
+  .try(() => Promise.all(regions.map((r) => opsWorks(r).describeStacksAsync().get('Stacks')
+    .then((stacks) => stacks.map((stack) => { stack.Region = r; return stack; }))))) // Replace the stack region for the region used to search for the stack
   .then((response) => [].concat.apply([], response))
   .filter(stack => createRegExp(name).test(stack.Name))
   .then(stacks => {

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,18 +21,33 @@ program
   .action(param => name = param)
   .option('-a, --all', 'list all instances besides those with online status')
   .option('-p, --profile [default]', 'the credential profile to use to authenticate on AWS', 'default')
+  .option('-r, --regions <regions>', 'the regions to search for instances, when not passed will search on all regions')
+  .option('-e, --ec2-api-region [region]', 'the ec2 api region, use this if you do not have access to us-east-1 and need to search on all regions', 'us-east-1')
   .parse(process.argv);
 
 if (typeof name === 'undefined') program.help();
 
 var credentials = new AWS.SharedIniFileCredentials({ profile: program.profile });
-var opsWorks = Promise.promisifyAll(new AWS.OpsWorks({
+var opsWorks = (region) => Promise.promisifyAll(new AWS.OpsWorks({
   credentials: credentials,
-  region: 'us-east-1'
+  region
 }));
 
+var regions = new Promise((resolve, reject) => {
+  if (program.regions) {
+    resolve(program.regions.split(","));
+  } else {
+    var ec2 = Promise.promisifyAll(new AWS.EC2({ credentials: credentials, region: program['ec2ApiRegion'] }));
+    Promise
+      .try(() => ec2.describeRegionsAsync().get('Regions'))
+      .map((r) => r.RegionName)
+      .then((regions) => resolve(regions));
+  }
+});
+
 Promise
-  .try(() => opsWorks.describeStacksAsync().get('Stacks'))
+  .try(() => Promise.all(regions.map((r) => opsWorks(r).describeStacksAsync().get('Stacks'))))
+  .then((response) => [].concat.apply([], response))
   .filter(stack => createRegExp(name).test(stack.Name))
   .then(stacks => {
     var stacksMap = _.keyBy(stacks, 'StackId');
@@ -40,11 +55,11 @@ Promise
     return Promise
       .props({
         layers: Promise
-          .map(stacks, stack => opsWorks.describeLayersAsync({ StackId: stack.StackId }).get('Layers'))
+          .map(stacks, stack => opsWorks(stack.Region).describeLayersAsync({ StackId: stack.StackId }).get('Layers'))
           .then(_.flatten)
           .then(layers => _.keyBy(layers, 'LayerId')),
         instances: Promise
-          .map(stacks, stack => opsWorks.describeInstancesAsync({ StackId: stack.StackId }).get('Instances'))
+          .map(stacks, stack => opsWorks(stack.Region).describeInstancesAsync({ StackId: stack.StackId }).get('Instances'))
           .then(_.flatten)
           .then(instances => program.all ? instances : instances.filter(instance => instance.Status === 'online'))
       })
@@ -53,14 +68,14 @@ Promise
           'Status',
           o => stacksMap[o.StackId].Name,
           o => result.layers[_.first(o.LayerIds)].Name,
-          'Hostname', 'Ec2InstanceId', 'PrivateIp'
+          'Hostname', 'Ec2InstanceId', 'PrivateIp', 'Region'
         ]);
 
         return [result.layers, instances];
       })
       .spread((layers, instances) => {
         let table = new Table({
-          head: [ 'Stack', 'Layer', 'Status', 'Hostname', 'Instance', 'Private IP' ],
+          head: [ 'Stack', 'Layer', 'Status', 'Hostname', 'Instance', 'Private IP', 'Region' ],
           style: { head: [ 'cyan' ] }
         });
 
@@ -70,7 +85,8 @@ Promise
           instance.Status === 'online' ? colors.green(instance.Status) : colors.red(instance.Status),
           instance.Hostname,
           instance.Ec2InstanceId,
-          instance.PrivateIp || '-'
+          instance.PrivateIp || '-',
+          stacksMap[instance.StackId].Region
         ]));
 
         return table;


### PR DESCRIPTION
Due to amazon allowing to create regional stacks, the stacks that were not on the us-east-1 region were not showing on the results.

I added the option to specify multiple regions and, when this option is not passed, the program will search on every available region using the ec2 API. That created another region-problem.

The EC2 api needs a region to list all regions, idk if there is another API to do this, but I needed to pass a region, b/c of that, i added another param to the command called ec2-api-region, this region only needs to be passed if the user is searching on all regions AND he doesn't have access to the us-east-1 region for EC2.

I think the regions call can be improved somehow, but I need some help for that ;)

